### PR TITLE
Fix payu comeback error

### DIFF
--- a/app/controllers/spree/gateway/payu_controller.rb
+++ b/app/controllers/spree/gateway/payu_controller.rb
@@ -6,16 +6,17 @@ module Spree
     def comeback
       payment = Spree::Payment.find_by("public_metadata->>'token' = ?", params[:order][:orderId])
 
-      if payment&.state == 'checkout' &&
-         payment.payment_method.verify_transaction(params[:order][:status],
-                                                   payment,
-                                                   params[:order][:totalAmount],
-                                                   params[:order][:currencyCode],
-                                                   params[:order][:orderId]) &&
-          payment.order.update_with_updater!
-        head :ok
-      else
+      if payment.nil?
+        Rails.logger.error "Payment not found for order: #{params[:order][:orderId]}"
         head :unprocessable_entity
+      else payment.state == 'checkout' &&
+        payment.payment_method.verify_transaction(params[:order][:status],
+                                                 payment,
+                                                 params[:order][:totalAmount],
+                                                 params[:order][:currencyCode],
+                                                 params[:order][:orderId]) &&
+        payment.order.update_with_updater!
+        head :ok
       end
     end
   end


### PR DESCRIPTION
A NoMethodError occurred while POST </gateway/payu/comeback/15/628344> was processed by payu#comeback
Exception
undefined method '[]' for nil
Hostname
neti
Backtrace
``````

I, [2025-01-16T13:42:44.690511 #3027387]  INFO -- : [6aac30ec-7422-4250-9deb-0e2942bf53dd] Started POST "/gateway/payu/comeback/15/628344" for 185.68.12.28 at 2025-01-16 13:42:44 +0000
I, [2025-01-16T13:42:44.692282 #3027387]  INFO -- : [6aac30ec-7422-4250-9deb-0e2942bf53dd] Processing by Spree::Gateway::PayuController#comeback as HTML
I, [2025-01-16T13:42:44.692389 #3027387]  INFO -- : [6aac30ec-7422-4250-9deb-0e2942bf53dd]   Parameters: {"orderId"=>"TMVJ711P5T250114GUEST000P01", "extOrderId"=>"YJCZK695073950|PHXDADQV", "refund"=>{"refundId"=>"138131880", "extRefundId"=>"20250116144125", "amount"=>"240100", "currencyCode"=>"CZK", "status"=>"FINALIZED", "statusDateTime"=>"2025-01-16T14:41:37.253+01:00", "reason"=>"refund", "reasonDescription"=>"Return YJCZK695073950", "refundDate"=>"2025-01-16T14:41:25.807+01:00"}, "gateway_id"=>"15", "order_id"=>"628344", "payu"=>{}}