### PR TITLE
[EK-372] Add availible_for_shipment_method? for payu model

### DIFF
--- a/app/models/spree/gateway/payu.rb
+++ b/app/models/spree/gateway/payu.rb
@@ -28,10 +28,15 @@ module Spree
     end
 
     def available_for_order?(order)
-      return false if preferred_min_payment_amount.present? && order.total <= preferred_min_payment_amount
-      return false if preferred_max_payment_amount.present? && order.total >= preferred_max_payment_amount
+      !below_min_payment_amount?(order) &&
+        !above_max_payment_amount?(order) &&
+        available_for_shipment_method?(order.shipments)
+    end
 
-      true
+    def available_for_shipment_method?(shipments)
+      shipping_method_ids ||= shipments.map { |shipment| shipment.shipping_method.id }.join(',')
+
+      preferred_delivery_method_ids.include?(shipping_method_ids)
     end
 
     def cancel(order_id, *args)
@@ -283,6 +288,14 @@ module Spree
     end
 
     private
+
+    def below_min_payment_amount?(order)
+      preferred_min_payment_amount.present? && order.total <= preferred_min_payment_amount
+    end
+
+    def above_max_payment_amount?(order)
+      preferred_max_payment_amount.present? && order.total >= preferred_max_payment_amount
+    end
 
     def simulated_successful_billing_response
       ActiveMerchant::Billing::Response.new(true, '', {}, {})

--- a/app/models/spree/gateway/payu.rb
+++ b/app/models/spree/gateway/payu.rb
@@ -277,14 +277,6 @@ module Spree
 
     private
 
-    def below_min_payment_amount?(order)
-      preferred_min_payment_amount.present? && order.total <= preferred_min_payment_amount
-    end
-
-    def above_max_payment_amount?(order)
-      preferred_max_payment_amount.present? && order.total >= preferred_max_payment_amount
-    end
-
     def simulated_successful_billing_response
       ActiveMerchant::Billing::Response.new(true, '', {}, {})
     end

--- a/app/models/spree/gateway/payu.rb
+++ b/app/models/spree/gateway/payu.rb
@@ -27,18 +27,6 @@ module Spree
       false
     end
 
-    def available_for_order?(order)
-      !below_min_payment_amount?(order) &&
-        !above_max_payment_amount?(order) &&
-        available_for_shipment_method?(order.shipments)
-    end
-
-    def available_for_shipment_method?(shipments)
-      shipping_method_ids ||= shipments.map { |shipment| shipment.shipping_method.id }.join(',')
-
-      preferred_delivery_method_ids.include?(shipping_method_ids)
-    end
-
     def cancel(order_id, *args)
       Rails.logger.debug("Starting cancellation for #{order_id}")
 

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -7,6 +7,18 @@ module Spree
       base.preference :delivery_method_ids, :string
       base.preference :image_url, :string
     end
+
+    def available_for_order?(order)
+      !below_min_payment_amount?(order) &&
+        !above_max_payment_amount?(order) &&
+        available_for_shipment_method?(order.shipments)
+    end
+
+    def available_for_shipment_method?(shipments)
+      shipping_method_ids ||= shipments.map { |shipment| shipment.shipping_method.id }.join(',')
+
+      preferred_delivery_method_ids.include?(shipping_method_ids)
+    end
   end
 end
 


### PR DESCRIPTION
[[EK-372]](https://yesbizuteria.atlassian.net/browse/EK-372)

### Description

Dodanie do modelu płatności payu sprawdzenia czy płatność payu jest dostępna dla danego typu dostawy.

## Type of change

- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Breaking change 🚨
- [ ] Documentation update 📚
- [ ] Refactor 🔨

### How to test

- update payu gem using branch EK-372
- log in as admin and go to payments tab
- choose payu payment
- add the ids of delivery methods for which PayU must be available to delivery metod ids to the delivery method IDs input field
- save changes
- go to store as customer
- add product to cart
- go to checkout
- after selecting a delivery method for which PayU is not available, the PayU payment method should not appear at checkout

### Screenshots

| Before.                                      | After.                                       |
| -------------------------------------------- | -------------------------------------------- |
| Insert screenshots or screen recordings      | Insert screenshots or screen recordings      |


## Checklist ✅

- [x] I have tested my code locally.
- [ ] I have updated documentation where necessary.
- [ ] I have linked the related issue (if any).

### Review

- [ ] Verify all copy with a content writer
- [ ] Get approval from at lest 2 team members (including Patryk).


### Other

Provide additional notes, remarks, links, mention specific people to review if need.
